### PR TITLE
Auto-Update Enhancement & Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ ___  _  _ _  _ | _  _
 </pre>
 </div>
 <div align="center">
-<a href="https://github.com/RaoFoundation/templar/blob/main/docs/incentive_design.md">Incentive Design</a> • <a href="https://github.com/RaoFoundation/templar/blob/main/docs/miner.md">Miner</a> • <a href="https://github.com/RaoFoundation/templar/blob/main/docs/validator.md">Validator</a>
+Documentation: <a href="https://github.com/RaoFoundation/templar/blob/main/docs/incentive_design.md">Incentive Design</a> • <a href="https://github.com/RaoFoundation/templar/blob/main/docs/miner.md">Miner</a> • <a href="https://github.com/RaoFoundation/templar/blob/main/docs/validator.md">Validator</a>
 </div>
 
-## Quick Start
+<!-- ## Quick Start
 
 ---
 
 <pre>
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/RaoFoundation/templar/main/scripts/run.sh)"
-</pre>
+</pre> -->

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -57,7 +57,8 @@ This document provides a guide on how to set up and run a validator using `valid
                 "s3:GetObject",
                 "s3:PutObjectVersionAcl",
                 "s3:GetObjectAttributes",
-                "s3:PutObjectAcl"
+                "s3:PutObjectAcl",
+                "s3:DeleteObject"
             ],
             "Resource": "arn:aws:s3:::<your-bucket-name>/*"
         }
@@ -78,7 +79,7 @@ This document provides a guide on how to set up and run a validator using `valid
 
 ## Installation
 
-### Automated Installation (Recommended)
+<!-- ### Automated Installation (Recommended)
 
 The easiest way to set up a validator is using the automated installation script:
 
@@ -102,7 +103,7 @@ The script will:
 2. Set up AWS credentials
 3. Create and register Bittensor wallet and validator hotkey
 4. Configure wandb for logging
-5. Start the validator
+5. Start the validator -->
 
 ### Manual Installation
 
@@ -185,8 +186,11 @@ pm2 start neurons/validator.py --interpreter python3 --name validator -- \
   --project <project_name> \
   --netuid <netuid> \
   --subtensor.network <network> \
+  --process_name validator \  # Must match PM2's --name
   --autoupdate \
   --remote
+
+> **Important**: When using PM2, the `--process_name` argument must match the PM2 process name specified by `--name`. In this example, PM2 process is named `validator`, so we use `--process_name validator`.
 
 # Monitor logs
 pm2 logs validator
@@ -197,6 +201,7 @@ pm2 list
 
 ### Important Flags
 
+- **`--process_name`**: (Required) Must match the PM2 process name when using PM2
 - **`--sync_state`**: Synchronizes model state with network history (crucial)
 - **`--actual_batch_size`**: Set based on GPU memory:
   - 80GB+ VRAM: batch size 6

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -75,7 +75,7 @@ class Miner:
         if config.autoupdate:
             from templar.autoupdate import AutoUpdate
             autoupdater = AutoUpdate()
-            autoupdater.try_update()
+            autoupdater.start()
         tplr.validate_bucket_or_exit(config.bucket)
         return config
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -46,7 +46,7 @@ class Miner:
     @staticmethod
     def config():
         parser = argparse.ArgumentParser(description='Miner script')
-        parser.add_argument('--project', type=str, default='aesop2', help='Optional wandb project name')
+        parser.add_argument('--project', type=str, default='templar', help='Optional wandb project name')
         parser.add_argument('--netuid', type=int, default=3, help='Bittensor network UID.')
         parser.add_argument('--bucket', type=str, default='decis', help='S3 bucket name')
         parser.add_argument('--actual_batch_size', type=int, default=8, help='Training batch size per accumulation.')

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -61,6 +61,8 @@ class Miner:
         parser.add_argument('--test', action='store_true', help='Run on test network')
         parser.add_argument('--local', action='store_true', help='Run on local network')
         parser.add_argument('--autoupdate', action='store_true', help='Enable automatic updates')
+        parser.add_argument("--process_name", type=str, help="The name of the PM2 process")
+
         bt.wallet.add_args(parser)
         bt.subtensor.add_args(parser)
         config = bt.config(parser)
@@ -74,7 +76,7 @@ class Miner:
         if config.trace: tplr.trace()
         if config.autoupdate:
             from templar.autoupdate import AutoUpdate
-            autoupdater = AutoUpdate()
+            autoupdater = AutoUpdate(process_name=config.process_name)
             autoupdater.start()
         tplr.validate_bucket_or_exit(config.bucket)
         return config

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -43,7 +43,7 @@ class Validator:
     @staticmethod
     def config():
         parser = argparse.ArgumentParser(description='Validator script')
-        parser.add_argument('--project', type=str, default='aesop2', help='Optional wandb project name')
+        parser.add_argument('--project', type=str, default='templar', help='Optional wandb project name')
         parser.add_argument('--netuid', type=int, default=3, help='Bittensor network UID.')
         parser.add_argument('--bucket', type=str, default='decis', help='S3 bucket name')
         parser.add_argument('--actual_batch_size', type=int, default=8, help='Training batch size per accumulation.')

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -70,7 +70,7 @@ class Validator:
         if config.autoupdate:
             from templar.autoupdate import AutoUpdate
             autoupdater = AutoUpdate()
-            autoupdater.try_update()
+            autoupdater.start()
         tplr.validate_bucket_or_exit(config.bucket)
         return config
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -69,7 +69,7 @@ class Validator:
         if config.trace: tplr.trace()
         if config.autoupdate:
             from templar.autoupdate import AutoUpdate
-            autoupdater = AutoUpdate()
+            autoupdater = AutoUpdate(process_name=config.process_name)
             autoupdater.start()
         tplr.validate_bucket_or_exit(config.bucket)
         return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "loguru==0.7.2",
     "uvloop==0.20.0",
     "aiofiles>=24.1.0",
+    "random2"
 ]
 
 [tool.uv]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,7 +25,7 @@ PROJECT=${2:-templar}
 
 # Start all the processes again.
 # pm2 start neurons/validator.py --interpreter python3 --name V2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey V1 --bucket $BUCKET --device cuda:0 --use_wandb --project $PROJECT --test --netuid 223
-PM2_PROCESS_NAME=M1 pm2 start neurons/miner.py --interpreter python3 --name M1 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M111 --bucket $BUCKET --device cuda:1 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate
+pm2 start neurons/miner.py --interpreter python3 --name M1 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M111 --bucket $BUCKET --device cuda:1 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name M1
 # pm2 start neurons/miner.py --interpreter python3 --name M2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M222 --bucket $BUCKET --device cuda:2 --use_wandb --project $PROJECT --test --netuid 223
 # pm2 start neurons/miner.py --interpreter python3 --name M3 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M333 --bucket $BUCKET --device cuda:3 --use_wandb --project $PROJECT --test --netuid 223
 # pm2 start neurons/miner.py --interpreter python3 --name M4 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M444 --bucket $BUCKET --device cuda:4 --use_wandb --project $PROJECT --test --netuid 223

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,7 +25,7 @@ PROJECT=${2:-templar}
 
 # Start all the processes again.
 # pm2 start neurons/validator.py --interpreter python3 --name V2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey V1 --bucket $BUCKET --device cuda:0 --use_wandb --project $PROJECT --test --netuid 223
-pm2 start neurons/miner.py --interpreter python3 --name M1 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M111 --bucket $BUCKET --device cuda:1 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate
+PM2_PROCESS_NAME=M1 pm2 start neurons/miner.py --interpreter python3 --name M1 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M111 --bucket $BUCKET --device cuda:1 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate
 # pm2 start neurons/miner.py --interpreter python3 --name M2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M222 --bucket $BUCKET --device cuda:2 --use_wandb --project $PROJECT --test --netuid 223
 # pm2 start neurons/miner.py --interpreter python3 --name M3 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M333 --bucket $BUCKET --device cuda:3 --use_wandb --project $PROJECT --test --netuid 223
 # pm2 start neurons/miner.py --interpreter python3 --name M4 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M444 --bucket $BUCKET --device cuda:4 --use_wandb --project $PROJECT --test --netuid 223

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,24 +16,23 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Close down all previous processes and restart them.
-# pm2 sendSignal SIGINT all
-# pm2 delete all
+pm2 sendSignal SIGINT all
+pm2 delete all
 # Delete items from bucket
 BUCKET=${1:-cont2}
 PROJECT=${2:-templar}
-# python3 tools/clean.py --bucket $BUCKET
+python3 tools/clean.py --bucket $BUCKET
 
 # Start all the processes again.
-# pm2 start neurons/validator.py --interpreter python3 --name V2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey V1 --bucket $BUCKET --device cuda:0 --use_wandb --project $PROJECT --test --netuid 223
+pm2 start neurons/validator.py --interpreter python3 --name V2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey V1 --bucket $BUCKET --device cuda:0 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name V2
 pm2 start neurons/miner.py --interpreter python3 --name M1 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M111 --bucket $BUCKET --device cuda:1 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name M1
-# pm2 start neurons/miner.py --interpreter python3 --name M2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M222 --bucket $BUCKET --device cuda:2 --use_wandb --project $PROJECT --test --netuid 223
-# pm2 start neurons/miner.py --interpreter python3 --name M3 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M333 --bucket $BUCKET --device cuda:3 --use_wandb --project $PROJECT --test --netuid 223
-# pm2 start neurons/miner.py --interpreter python3 --name M4 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M444 --bucket $BUCKET --device cuda:4 --use_wandb --project $PROJECT --test --netuid 223
-# pm2 start neurons/miner.py --interpreter python3 --name M5 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M555 --bucket $BUCKET --device cuda:5 --use_wandb --project $PROJECT --test --netuid 223
-# pm2 start neurons/miner.py --interpreter python3 --name M6 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M666 --bucket $BUCKET --device cuda:6 --use_wandb --project $PROJECT --test --netuid 223
+pm2 start neurons/miner.py --interpreter python3 --name M2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M222 --bucket $BUCKET --device cuda:2 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name M2
+pm2 start neurons/miner.py --interpreter python3 --name M3 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M333 --bucket $BUCKET --device cuda:3 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name M3
+pm2 start neurons/miner.py --interpreter python3 --name M4 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M444 --bucket $BUCKET --device cuda:4 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name M4
+pm2 start neurons/miner.py --interpreter python3 --name M5 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M555 --bucket $BUCKET --device cuda:5 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name M5
+pm2 start neurons/miner.py --interpreter python3 --name M6 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M666 --bucket $BUCKET --device cuda:6 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate --process_name M6
 
 
-# pm2 start neurons/miner.py --interpreter python3 --name M6 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M666 --bucket $BUCKET --device cuda:6 --use_wandb --project $PROJECT --test --netuid 223
 
 
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,21 +16,24 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Close down all previous processes and restart them.
-pm2 sendSignal SIGINT all
-pm2 delete all
+# pm2 sendSignal SIGINT all
+# pm2 delete all
 # Delete items from bucket
 BUCKET=${1:-cont2}
-PROJECT=${2:-templar_run}
+PROJECT=${2:-templar}
 # python3 tools/clean.py --bucket $BUCKET
 
 # Start all the processes again.
-pm2 start neurons/validator.py --interpreter python3 --name V2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey V1 --bucket $BUCKET --device cuda:0 --use_wandb --project $PROJECT --test --netuid 223
-pm2 start neurons/miner.py --interpreter python3 --name M1 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M111 --bucket $BUCKET --device cuda:1 --use_wandb --project $PROJECT --test --netuid 223
-pm2 start neurons/miner.py --interpreter python3 --name M2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M222 --bucket $BUCKET --device cuda:2 --use_wandb --project $PROJECT --test --netuid 223
-pm2 start neurons/miner.py --interpreter python3 --name M3 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M333 --bucket $BUCKET --device cuda:3 --use_wandb --project $PROJECT --test --netuid 223
-pm2 start neurons/miner.py --interpreter python3 --name M4 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M444 --bucket $BUCKET --device cuda:4 --use_wandb --project $PROJECT --test --netuid 223
-pm2 start neurons/miner.py --interpreter python3 --name M5 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M555 --bucket $BUCKET --device cuda:5 --use_wandb --project $PROJECT --test --netuid 223
-pm2 start neurons/miner.py --interpreter python3 --name M6 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M666 --bucket $BUCKET --device cuda:6 --use_wandb --project $PROJECT --test --netuid 223
+# pm2 start neurons/validator.py --interpreter python3 --name V2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey V1 --bucket $BUCKET --device cuda:0 --use_wandb --project $PROJECT --test --netuid 223
+pm2 start neurons/miner.py --interpreter python3 --name M1 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M111 --bucket $BUCKET --device cuda:1 --use_wandb --project $PROJECT --test --netuid 223 --autoupdate
+# pm2 start neurons/miner.py --interpreter python3 --name M2 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M222 --bucket $BUCKET --device cuda:2 --use_wandb --project $PROJECT --test --netuid 223
+# pm2 start neurons/miner.py --interpreter python3 --name M3 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M333 --bucket $BUCKET --device cuda:3 --use_wandb --project $PROJECT --test --netuid 223
+# pm2 start neurons/miner.py --interpreter python3 --name M4 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M444 --bucket $BUCKET --device cuda:4 --use_wandb --project $PROJECT --test --netuid 223
+# pm2 start neurons/miner.py --interpreter python3 --name M5 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M555 --bucket $BUCKET --device cuda:5 --use_wandb --project $PROJECT --test --netuid 223
+# pm2 start neurons/miner.py --interpreter python3 --name M6 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M666 --bucket $BUCKET --device cuda:6 --use_wandb --project $PROJECT --test --netuid 223
+
+
+# pm2 start neurons/miner.py --interpreter python3 --name M6 -- --actual_batch_size 1 --wallet.name Bistro --wallet.hotkey M666 --bucket $BUCKET --device cuda:6 --use_wandb --project $PROJECT --test --netuid 223
 
 
 

--- a/src/templar/__init__.py
+++ b/src/templar/__init__.py
@@ -24,4 +24,4 @@ from .comms import *
 from .autoupdate import *
 from .learning_rates import *
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -183,6 +183,7 @@ class AutoUpdate(threading.Thread):
             logger.info("Detected PM2 environment. Exiting for PM2 to restart the process.")
             subprocess.check_call(["pm2", "restart", os.getenv("PM2_PROCESS_NAME")])
             sys.exit(1)
+        # Not tested
         elif os.getenv("RUNNING_IN_DOCKER") == "true" or os.path.exists('/.dockerenv'):
             # In Docker, it's better to exit and let the orchestrator handle restarts
             logger.info("Detected Docker environment. Exiting for Docker to restart the container.")

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -181,7 +181,7 @@ class AutoUpdate(threading.Thread):
         if "PM2_HOME" in os.environ:
             # PM2 will restart the process if we exit
             logger.info("Detected PM2 environment. Exiting for PM2 to restart the process.")
-            sys.exit(0)
+            sys.exit(1)
         elif os.getenv("RUNNING_IN_DOCKER") == "true" or os.path.exists('/.dockerenv'):
             # In Docker, it's better to exit and let the orchestrator handle restarts
             logger.info("Detected Docker environment. Exiting for Docker to restart the container.")

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -12,7 +12,7 @@ from . import logger
 # Import the local version
 from .__init__ import __version__
 
-TARGET_BRANCH = "main"
+TARGET_BRANCH = "test_autoupdate"
 
 class AutoUpdate(threading.Thread):
     """
@@ -34,7 +34,7 @@ class AutoUpdate(threading.Thread):
         """
         try:
             # Perform a git fetch to ensure we have the latest remote information
-            self.repo.remotes.origin.fetch(timeout=5)
+            self.repo.remotes.origin.fetch(kill_after_timeout=5)
 
             # Get version number from remote __init__.py
             init_blob = (
@@ -158,9 +158,9 @@ class AutoUpdate(threading.Thread):
         """
         Automatic update entrypoint method.
         """
-        if self.repo.head.is_detached or self.repo.active_branch.name != TARGET_BRANCH:
-            logger.debug("Not on the target branch, skipping auto-update")
-            return
+        # if self.repo.head.is_detached or self.repo.active_branch.name != TARGET_BRANCH:
+        #     logger.info("Not on the target branch, skipping auto-update")
+        #     return
 
         if not self.check_version_updated():
             return
@@ -194,6 +194,7 @@ class AutoUpdate(threading.Thread):
         """Thread run method to periodically check for updates."""
         while True:
             try:
+                logger.info("Running autoupdate")
                 self.try_update()
             except Exception as e:
                 logger.exception("Exception during autoupdate check", exc_info=e)

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -12,7 +12,7 @@ from . import logger
 # Import the local version
 from .__init__ import __version__
 
-TARGET_BRANCH = "test_autoupdate"
+TARGET_BRANCH = "main"
 
 class AutoUpdate(threading.Thread):
     """
@@ -101,9 +101,9 @@ class AutoUpdate(threading.Thread):
                 )
                 return False
             try:
-                logger.info("Attempting to pull the latest changes...")
-                origin.pull(kill_after_timeout=10)
-                logger.info("Successfully pulled the latest changes")
+                logger.debug("Attempting to pull the latest changes...")
+                origin.pull(TARGET_BRANCH, kill_after_timeout=10, rebase=True)
+                logger.debug("Successfully pulled the latest changes")
                 return True
             except git.GitCommandError as e:
                 logger.exception(
@@ -214,5 +214,4 @@ class AutoUpdate(threading.Thread):
                 self.try_update()
             except Exception as e:
                 logger.exception("Exception during autoupdate check", exc_info=e)
-            # time.sleep(self.interval_hours * 3600)  # Sleep for specified hours
-            time.sleep(5)  # Sleep for specified hours
+            time.sleep(self.interval_hours * 3600)  # Sleep for specified hours

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -1,10 +1,10 @@
 import os
-import subprocess
 import sys
+import threading
+import time
 import git
-import hashlib
+import subprocess
 from packaging import version
-from typing import Optional
 
 # Import local modules
 from . import logger
@@ -14,48 +14,27 @@ from .__init__ import __version__
 
 TARGET_BRANCH = "main"
 
-
-class AutoUpdate:
+class AutoUpdate(threading.Thread):
     """
     Automatic update utility for templar neurons.
     """
 
-    def __init__(self):
+    def __init__(self, interval_hours=4):
+        super().__init__()
+        self.interval_hours = interval_hours
+        self.daemon = True  # Ensure thread exits when main program exits
         try:
             self.repo = git.Repo(search_parent_directories=True)
-            self.update_requirements = False
         except Exception as e:
             logger.exception("Failed to initialize the repository", exc_info=e)
 
-    def get_remote_version(self) -> Optional[str]:
+    def get_remote_version(self):
         """
         Fetch the remote version string from the src/templar/__init__.py file in the repository.
         """
         try:
             # Perform a git fetch to ensure we have the latest remote information
             self.repo.remotes.origin.fetch(timeout=5)
-
-            # Check if the requirements.txt file has changed
-            local_requirements_path = os.path.join(
-                self.repo.working_tree_dir, "requirements.txt"
-            )
-            with open(local_requirements_path, "r", encoding="utf-8") as file:
-                local_requirements_hash = hashlib.sha256(
-                    file.read().encode("utf-8")
-                ).hexdigest()
-
-            requirements_blob = (
-                self.repo.remote().refs[TARGET_BRANCH].commit.tree / "requirements.txt"
-            )
-            remote_requirements_content = requirements_blob.data_stream.read().decode(
-                "utf-8"
-            )
-            remote_requirements_hash = hashlib.sha256(
-                remote_requirements_content.encode("utf-8")
-            ).hexdigest()
-            self.update_requirements = (
-                local_requirements_hash != remote_requirements_hash
-            )
 
             # Get version number from remote __init__.py
             init_blob = (
@@ -118,11 +97,10 @@ class AutoUpdate:
                 return True
             except git.GitCommandError as e:
                 logger.exception(
-                    "Automatic update failed due to conflicts. Attempting to handle merge conflicts...",
+                    "Automatic update failed due to conflicts. Attempting to handle merge conflicts.",
                     exc_info=e,
                 )
                 return self.handle_merge_conflicts()
-
         except Exception as e:
             logger.exception(
                 "Automatic update failed. Manually pull the latest changes and update.",
@@ -160,24 +138,21 @@ class AutoUpdate:
 
     def attempt_package_update(self):
         """
-        Attempt to update the packages by installing the requirements from the requirements.txt file.
+        Synchronize dependencies using 'uv sync --extra all'.
         """
-        logger.info("Attempting to update packages...")
+        logger.info("Attempting to update packages using 'uv sync --extra all'...")
 
         try:
-            repo = git.Repo(search_parent_directories=True)
-            repo_path: str = repo.working_tree_dir or ""
+            uv_executable = "uv"
+            # Optionally, specify the path to 'uv' if it's not in PATH
 
-            requirements_path = os.path.join(repo_path, "requirements.txt")
-
-            python_executable = sys.executable
             subprocess.check_call(
-                [python_executable, "-m", "pip", "install", "-r", requirements_path],
-                timeout=60,
+                [uv_executable, "sync", "--extra", "all"],
+                timeout=300,
             )
-            logger.info("Successfully updated packages.")
+            logger.info("Successfully updated packages using 'uv sync --extra all'.")
         except Exception as e:
-            logger.exception("Failed to update requirements", exc_info=e)
+            logger.exception("Failed to synchronize dependencies with uv", exc_info=e)
 
     def try_update(self):
         """
@@ -193,11 +168,34 @@ class AutoUpdate:
         if not self.attempt_update():
             return
 
-        if self.update_requirements:
-            self.attempt_package_update()
+        # Synchronize dependencies
+        self.attempt_package_update()
 
-        restart_app()
+        # Restart application
+        self.restart_app()
 
-def restart_app():
-    """Restarts the current application."""
-    os.execv(sys.executable, [sys.executable] + sys.argv)
+    def restart_app(self):
+        """Restarts the current application appropriately based on the runtime environment."""
+        logger.info("Restarting application...")
+        # Check for PM2 environment
+        if "PM2_HOME" in os.environ:
+            # PM2 will restart the process if we exit
+            logger.info("Detected PM2 environment. Exiting for PM2 to restart the process.")
+            sys.exit(0)
+        elif os.getenv("RUNNING_IN_DOCKER") == "true" or os.path.exists('/.dockerenv'):
+            # In Docker, it's better to exit and let the orchestrator handle restarts
+            logger.info("Detected Docker environment. Exiting for Docker to restart the container.")
+            sys.exit(0)
+        else:
+            # Regular restart
+            os.execv(sys.executable, [sys.executable] + sys.argv)
+
+    def run(self):
+        """Thread run method to periodically check for updates."""
+        while True:
+            try:
+                self.try_update()
+            except Exception as e:
+                logger.exception("Exception during autoupdate check", exc_info=e)
+            # time.sleep(self.interval_hours * 3600)  # Sleep for specified hours
+            time.sleep(5)  # Sleep for specified hours

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -181,6 +181,7 @@ class AutoUpdate(threading.Thread):
         if "PM2_HOME" in os.environ:
             # PM2 will restart the process if we exit
             logger.info("Detected PM2 environment. Exiting for PM2 to restart the process.")
+            subprocess.check_call(["pm2", "restart", os.getenv("PM2_PROCESS_NAME")])
             sys.exit(1)
         elif os.getenv("RUNNING_IN_DOCKER") == "true" or os.path.exists('/.dockerenv'):
             # In Docker, it's better to exit and let the orchestrator handle restarts

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -92,7 +92,7 @@ class AutoUpdate(threading.Thread):
                 return False
             try:
                 logger.info("Attempting to pull the latest changes...")
-                origin.pull(timeout=10)
+                origin.pull(kill_after_timeout=10)
                 logger.info("Successfully pulled the latest changes")
                 return True
             except git.GitCommandError as e:

--- a/src/templar/autoupdate.py
+++ b/src/templar/autoupdate.py
@@ -168,9 +168,9 @@ class AutoUpdate(threading.Thread):
         """
         Automatic update entrypoint method.
         """
-        # if self.repo.head.is_detached or self.repo.active_branch.name != TARGET_BRANCH:
-        #     logger.info("Not on the target branch, skipping auto-update")
-        #     return
+        if self.repo.head.is_detached or self.repo.active_branch.name != TARGET_BRANCH:
+            logger.info("Not on the target branch, skipping auto-update")
+            return
 
         if not self.check_version_updated():
             return


### PR DESCRIPTION
## Changes
- **Auto-Update Mechanism**: 
  - Implements a daemon thread that checks for updates every 4 hours
  - Compares local and remote versions from `main` branch
  - Automatically pulls changes and restarts process if newer version detected
  - For PM2 users: `--process_name` flag is now required and must match PM2's process name (e.g., `--name miner_C0` → `--process_name miner_C0`)

- **Documentation**:
  - Updated miner/validator setup instructions
  - Added PM2 process naming requirements
  - Added auto-update configuration details

- **Startup Script**:
  - Temporarily disabled `run.sh` instructions due to mainnet registration limitations (3 slots/interval)
  - Will re-enable once registration constraints are resolved
