### PR TITLE
Fix/update task

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -148,24 +148,31 @@ class Validator:
     async def update(self):
         while not self.stop_event.is_set():
             st = tplr.T()
-            self.subtensor = bt.subtensor(config=self.config)
-            self.metagraph = self.subtensor.metagraph(self.config.netuid)
-            self.hparams = tplr.load_hparams()
-            next_buckets = []
-            for uid in self.metagraph.uids:
-                try:
-                    bucket = self.config.bucket if not self.config.remote else self.subtensor.get_commitment(self.config.netuid, uid)
-                    if tplr.is_valid_bucket(bucket):
-                        next_buckets.append(bucket)
-                    else:
-                        logger.debug(f"Skipping UID {uid} due to invalid bucket name: {bucket}")
-                        next_buckets.append(None)
-                except Exception as e:
-                    logger.exception(f"Error retrieving bucket for UID {uid}: {e}")
-                    next_buckets.append(None)
-            self.buckets = next_buckets
+            # Run the blocking update operations in a separate thread
+            await asyncio.to_thread(self.perform_update)
             tplr.logger.info(f"{tplr.P(self.current_window, tplr.T() - st)} Updated global state.")
             await asyncio.sleep(60)
+
+    def perform_update(self):
+        self.subtensor = bt.subtensor(config=self.config)
+        self.metagraph = self.subtensor.metagraph(self.config.netuid)
+        self.hparams = tplr.load_hparams()
+        next_buckets = []
+        for uid in self.metagraph.uids:
+            try:
+                if not self.config.remote:
+                    bucket = self.config.bucket
+                else:
+                    bucket = self.subtensor.get_commitment(self.config.netuid, uid)
+                if tplr.is_valid_bucket(bucket):
+                    next_buckets.append(bucket)
+                else:
+                    tplr.logger.debug(f"Skipping UID {uid} due to invalid or missing bucket name: {bucket}")
+                    next_buckets.append(None)
+            except Exception as e:
+                tplr.logger.debug(f"Error retrieving bucket for UID {uid}: {e}")
+                next_buckets.append(None)
+        self.buckets = next_buckets
 
     async def run(self):
         # Main loop.

--- a/src/templar/comms.py
+++ b/src/templar/comms.py
@@ -40,16 +40,15 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 # Define a semaphore to limit concurrent downloads (adjust as needed)
 semaphore = asyncio.Semaphore(1000)
 
-async def get_slices( filename:str, device:str ) -> Dict[str, torch.Tensor]:
-    # Attempt to acquire the lock with a timeout of 1 second.
+async def get_slices(filename: str, device: str) -> Dict[str, torch.Tensor]:
     lock: FileLock = FileLock(f"{filename}.lock")
     with lock.acquire(timeout=5):
-        pass
-    return torch.load(
-        filename,
-        map_location=torch.device(device),
-        weights_only = True,
-    )
+        # Lock is held during the entire read operation
+        return torch.load(
+            filename,
+            map_location=torch.device(device),
+            weights_only=True,
+        )
 
 async def apply_slices_to_model(model: torch.nn.Module, window: int, seed: str, compression: int, key:str = 'slice') -> List[str]:
     """


### PR DESCRIPTION
**Changes**

### Fix Error with Update Task
- **Corrected Logger Reference:** Fixed an issue where the update task was not executing as expected because we were using the incorrect logger instance. Changed instances of logger to tplr.logger within the update() method to ensure proper logging and that the method runs.
- **Identified Blocking Calls in update()**: The correction exposed that the update task was actually blocking the event loop.
Even though update() is an async method, it contained blocking calls to subtensor, which halted the event loop until completion.
This blocking prevented the training loop and other asynchronous tasks from progressing concurrently.

### Event Loop Non-Blocking Update:

- **Fixed Blocking Issue in `update()` Method:**
  - Refactored the `update()` coroutine to prevent it from blocking the event loop.
  - Moved blocking operations into a separate function `perform_update()`.
  - Used `await asyncio.to_thread(self.perform_update)` within `update()` to run blocking code in a separate thread.


**Implementation Details**

- The `update()` coroutine now asynchronously calls `perform_update()` using `asyncio.to_thread()`, ensuring that the event loop remains responsive.
  
  ```python
  async def update(self):
      while not self.stop_event.is_set():
          st = tplr.T()
          await asyncio.to_thread(self.perform_update)
          tplr.logger.info(f"{tplr.P(self.current_window, tplr.T() - st)} Updated global state.")
          await asyncio.sleep(60)
  ```

- Blocking operations are encapsulated within `perform_update()`, which runs in a separate thread.

  ```python
  def perform_update(self):
      self.subtensor = bt.subtensor(config=self.config)
      self.metagraph = self.subtensor.metagraph(self.config.netuid)
      self.hparams = tplr.load_hparams()
      # Rest of the blocking code...
  ```

By applying these changes, the `update()` coroutine no longer blocks the event loop, allowing the training process and other asynchronous tasks to run concurrently.