### PR TITLE
feat: implement checkpointing, multithreaded commitments

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -1,0 +1,124 @@
+# Checkpointing in Miners and Validators
+
+This document explains the checkpointing mechanism used in both miners and validators, highlighting the process and key differences between them.
+
+## Overview
+
+Checkpointing is a crucial feature that allows miners and validators to save their current state periodically. This enables them to resume operations seamlessly after interruptions, such as crashes or restarts, without losing significant progress.
+
+- **Miners** save their training state, including the model parameters, optimizer state, scheduler state, and current training step.
+- **Validators** save their evaluation state, including the model parameters, evaluation scores, weights, and current evaluation step.
+
+## Asynchronous Checkpoint Saving
+
+Both miners and validators utilize asynchronous checkpoint saving to prevent blocking the main training or evaluation loops. By saving checkpoints asynchronously, the processes can continue their operations without waiting for the checkpoint to be saved, enhancing performance and efficiency.
+
+### Key Features
+
+- **Non-Blocking**: Checkpoint saving runs in the background, allowing the main loop to proceed without delays.
+- **Regular Intervals**:
+  - **Miners**: Save checkpoints every **500 training steps** (`global_step`).
+  - **Validators**: Save checkpoints every **500 blocks** based on the blockchain's block number.
+
+## Checkpointing in Miners
+
+### What is Saved
+
+- **Model State**: The current state of the model's parameters.
+- **Optimizer State**: State of the optimizer to resume training seamlessly.
+- **Scheduler State**: If a learning rate scheduler is used.
+- **Global Step**: The current training step (`global_step`).
+- **Additional State**: Any other variables necessary for training.
+
+### Saving Mechanism
+
+- Checkpoints are saved asynchronously every 500 training steps.
+- The saving process uses asynchronous tasks to offload the I/O operations.
+- Default checkpoint file is `miner_checkpoint.pth`.
+
+### Restoring from Checkpoint
+
+- On startup, the miner checks for the existence of the checkpoint file.
+- If found, it loads the saved states and resumes training from the saved `global_step`.
+- No additional flags are required for checkpoint loading.
+
+## Checkpointing in Validators
+
+### What is Saved
+
+- **Model State**: The current state of the model's parameters.
+- **Global Step**: The current evaluation step (`global_step`).
+- **Scores**: Evaluation scores for different miners.
+- **Weights**: Assigned weights based on evaluation.
+- **Additional State**: Any other variables necessary for evaluation.
+
+### Saving Mechanism
+
+- Checkpoints are saved asynchronously every 500 blocks.
+- The checkpointing is triggered based on the blockchain's block number.
+- Uses asynchronous tasks to prevent blocking the evaluation loop.
+- Default checkpoint file is `validator_checkpoint.pth`.
+
+### Restoring from Checkpoint
+
+- On startup, the validator checks for the existence of the checkpoint file.
+- If found, it loads the saved states and resumes evaluation from the saved `global_step`.
+- No additional flags are required for checkpoint loading.
+
+## Differences Between Miner and Validator Checkpoints
+
+| Aspect               | Miner                                                | Validator                                              |
+|----------------------|------------------------------------------------------|--------------------------------------------------------|
+| **Saving Frequency** | Every 500 **training steps** (`global_step`)         | Every 500 **blocks** (blockchain block number)         |
+| **Trigger Condition**| `global_step % 500 == 0`                             | `current_block % 500 == 0`                             |
+| **Saved States**     | Model state, optimizer, scheduler, global step, etc. | Model state, global step, scores, weights, etc.        |
+| **Checkpoint File**  | `miner_checkpoint.pth`                               | `validator_checkpoint.pth`                             |
+| **Restoration**      | Resumes training from saved `global_step`            | Resumes evaluation from saved `global_step`            |
+
+## Configuration
+
+### Setting the Checkpoint Path
+
+By default, the checkpoint files are saved with the names `miner_checkpoint.pth` and `validator_checkpoint.pth`. You can customize the checkpoint path using the `--checkpoint_path` argument when running the miner or validator.
+
+**Example**:
+
+```bash
+# For Miner
+python neurons/miner.py --checkpoint_path /path/to/custom_miner_checkpoint.pth
+
+# For Validator
+python neurons/validator.py --checkpoint_path /path/to/custom_validator_checkpoint.pth
+```
+
+### Ensure Write Permissions
+
+Make sure that the process has read and write permissions to the directory where the checkpoint files are stored.
+
+## Best Practices
+
+- **Regular Monitoring**: Check logs to ensure that checkpoints are being saved and loaded correctly.
+- **Avoid Overwriting**: Ensure that `global_step` is not being unintentionally reset after loading from a checkpoint.
+- **Backup Checkpoints**: Periodically back up checkpoint files to prevent data loss.
+- **Consistent Paths**: Use consistent checkpoint paths when running multiple processes to avoid confusion.
+
+## Troubleshooting
+
+- **Checkpoint Not Saving**:
+  - Verify that the checkpoint path is correct.
+  - Ensure the process has write permissions to the checkpoint location.
+  - Check for any errors in the logs during the checkpoint saving steps.
+- **Global Step Reset to Zero**:
+  - Check that `global_step` is not being reinitialized after loading the checkpoint.
+  - Remove any code that sets `global_step = 0` after loading.
+- **Checkpoint Not Loading**:
+  - Ensure the checkpoint file exists at the specified path.
+  - Verify that the file is not corrupted.
+  - Check logs for any exceptions during the loading process.
+- **Asynchronous Saving Issues**:
+  - Ensure that the event loop is running correctly.
+  - Check for exceptions in the asynchronous tasks.
+
+## Conclusion
+
+Checkpointing is essential for maintaining continuity in mining and validation operations. By understanding the differences and properly configuring your setup, you can ensure efficient and reliable performance of your miner and validator nodes.

--- a/src/templar/__init__.py
+++ b/src/templar/__init__.py
@@ -23,5 +23,4 @@ from .hparams import *
 from .comms import *
 from .autoupdate import *
 from .learning_rates import *
-
 __version__ = "0.1.1"


### PR DESCRIPTION
# **Changes**

### Implement Asynchronous Checkpointing
- **Added Async Checkpoint Saving:** Implemented asynchronous checkpoint saving to prevent blocking the main training/validation loops.
- **Checkpoint Frequency:** Set up automatic checkpointing every 500 steps for miners and every 500 blocks for validators.
- **State Persistence:** Ensures training and validation progress is preserved across restarts.

### Global Step Persistence:

- **Fixed Global Step Reset Issue:**
  - Corrected the initialization of `global_step` to properly restore from checkpoints.
  - Removed redundant reinitialization that was causing the step counter to reset.
  - Ensures continuous progress tracking across sessions.

### Checkpoint State Management:

- **Miner Checkpoint State:**
  - Model state
  - Optimizer state
  - Scheduler state
  - Global step
  - Training progress

- **Validator Checkpoint State:**
  - Model state
  - Global step
  - Scores
  - Weights
  - Evaluation progress

**Implementation Details**

- Asynchronous checkpoint saving using `asyncio.create_task()`:
  
  ```python
  # Schedule the save_checkpoint function to run asynchronously
  asyncio.create_task(save_checkpoint(
      filename=self.checkpoint_path,
      model=self.model,
      optimizer=self.optimizer,
      scheduler=self.scheduler,
      global_step=self.global_step
  ))
  ```

- Proper checkpoint loading and state restoration:

  ```python
  if os.path.exists(self.checkpoint_path):
      global_step, _ = asyncio.run(load_checkpoint(
          filename=self.checkpoint_path,
          model=self.model,
          optimizer=self.optimizer,
          scheduler=self.scheduler,
          device=self.config.device
      ))
      self.global_step = global_step  # Properly restore global_step
  ```

By implementing these changes:
- Training and validation progress is preserved across sessions
- Checkpoint operations don't block the main processing loops
- Global step counting remains consistent after restarts
- Different checkpoint states are maintained for miners and validators

### Documentation
- Added comprehensive checkpointing documentation in `docs/checkpointing.md`
- Detailed explanation of miner vs validator checkpoint differences
- Troubleshooting guide for common checkpointing issues

I'll add this change to the PR notes. Here's the updated section:


### Optimize Bucket Commitment Fetching
- **Multi-threaded Commitment Retrieval:**
  - Implemented parallel fetching of bucket commitments using ThreadPoolExecutor
  - Reduced blocking time when retrieving commitments from multiple UIDs
  - Improved update task efficiency with concurrent bucket fetching

### Event Loop Non-Blocking Update:
- **Refactored `update()` Method:**
  - Moved blocking operations to separate `perform_update()` function
  - Used `asyncio.to_thread()` to prevent event loop blocking
  - Added parallel bucket commitment fetching

**Implementation Details**

```python
async def update(self):
    while not self.stop_event.is_set():
        st = tplr.T()
        # Run the blocking update operations in a separate thread
        await asyncio.to_thread(self.perform_update)
        tplr.logger.info(f"{tplr.P(self.current_window, tplr.T() - st)} Updated global state.")
        await asyncio.sleep(600)

def perform_update(self):
    self.subtensor = bt.subtensor(config=self.config)
    self.metagraph = self.subtensor.metagraph(self.config.netuid)
    self.hparams = tplr.load_hparams()

    def get_bucket(uid):
        try:
            bucket = self.config.bucket if not self.config.remote else self.subtensor.get_commitment(self.config.netuid, uid)
            if tplr.is_valid_bucket(bucket):
                return bucket
            else:
                tplr.logger.debug(f"Skipping UID {uid} due to invalid or missing bucket name: {bucket}")
                return None
        except Exception as e:
            tplr.logger.debug(f"Error retrieving bucket for UID {uid}: {e}")
            return None

    # Parallel bucket commitment fetching
    with ThreadPoolExecutor() as executor:
        next_buckets = list(executor.map(get_bucket, self.metagraph.uids))

    self.buckets = next_buckets
```

By implementing these changes:
- Bucket commitments are fetched concurrently, improving performance
- Update task runs in a separate thread, preventing event loop blocking
- Failed bucket retrievals are properly handled and logged
- Overall update process is more efficient and responsive
