### PR TITLE
Refactor: Wandb

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -123,26 +123,13 @@ class Miner:
             tplr.logger.info("Starting a new WandB run.")
 
         # Initialize WandB
-        wandb.init(
-            project=f"{self.config.project}-{tplr.__version__}",
-            entity='tplr',
-            resume='allow',
-            id=run_id,
-            name=f'M{self.uid}',
+        self.wandb = tplr.initialize_wandb(
+            run_prefix='M',
+            uid=self.uid,
             config=self.config,
             group='miner',
-            job_type='training',
-            dir=wandb_dir,  # Specify the wandb directory
-            anonymous='allow',
+            job_type='training'
         )
-
-        # Save the run ID if starting a new run
-        if run_id is None:
-            run_id = wandb.run.id
-            with open(run_id_file, 'w') as f:
-                f.write(run_id)
-            tplr.logger.info(f"Started new WandB run with id {run_id}")
-
 
         # Init model.
         tplr.logger.info('\n' + '-' * 40 + ' Hparams ' + '-' * 40)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -123,25 +123,13 @@ class Validator:
             tplr.logger.info("Starting a new WandB run.")
 
         # Initialize WandB
-        wandb.init(
-            project=f"{self.config.project}-{tplr.__version__}",
-            entity='tplr',
-            resume='allow',
-            id=run_id,
-            name=f'V{self.uid}',
+        self.wandb = tplr.initialize_wandb(
+            run_prefix='V',
+            uid=self.uid,
             config=self.config,
             group='validator',
-            job_type='validation',
-            dir=wandb_dir,  # Specify the wandb directory
-            anonymous='allow',
+            job_type='validation'
         )
-
-        # Save the run ID if starting a new run
-        if run_id is None:
-            run_id = wandb.run.id
-            with open(run_id_file, 'w') as f:
-                f.write(run_id)
-            tplr.logger.info(f"Started new WandB run with id {run_id}")
         self.metrics_history = pd.DataFrame()
         # Init model.
         tplr.logger.info('\n' + '-' * 40 + ' Hparams ' + '-' * 40)

--- a/src/templar/__init__.py
+++ b/src/templar/__init__.py
@@ -25,3 +25,4 @@ from .dataset import *
 from .hparams import *
 from .learning_rates import *
 from .logging import *
+from .wandb import *

--- a/src/templar/__init__.py
+++ b/src/templar/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # Import package.
 from .autoupdate import *

--- a/src/templar/wandb.py
+++ b/src/templar/wandb.py
@@ -50,7 +50,7 @@ def initialize_wandb(run_prefix, uid, config, group, job_type):
         config=config,
         group=group,
         job_type=job_type,
-        dir=wandb_dir,  # Specify the wandb directory
+        dir=wandb_dir,
         anonymous='allow',
     )
 

--- a/src/templar/wandb.py
+++ b/src/templar/wandb.py
@@ -1,0 +1,64 @@
+# The MIT License (MIT)
+# © 2024 templar.tech
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+# fmt: off
+
+
+import os
+import wandb
+from templar import __version__, logger
+
+def initialize_wandb(run_prefix, uid, config, group, job_type):
+    # Ensure the wandb directory exists
+    wandb_dir = os.path.join(os.getcwd(), 'wandb')
+    os.makedirs(wandb_dir, exist_ok=True)
+
+    # Define the run ID file path inside the wandb directory
+    run_id_file = os.path.join(
+        wandb_dir, f"wandb_run_id_{run_prefix}{uid}_{__version__}.txt"
+    )
+
+    # Attempt to read the existing run ID
+    if os.path.exists(run_id_file):
+        with open(run_id_file, 'r') as f:
+            run_id = f.read().strip()
+        logger.info(f"Resuming WandB run with id {run_id}")
+    else:
+        run_id = None
+        logger.info("Starting a new WandB run.")
+
+    # Initialize WandB
+    wandb.init(
+        project=f"{config.project}-v{__version__}",
+        entity='tplr',
+        resume='allow',
+        id=run_id,
+        name=f'{run_prefix}{uid}',
+        config=config,
+        group=group,
+        job_type=job_type,
+        dir=wandb_dir,  # Specify the wandb directory
+        anonymous='allow',
+    )
+
+    # Save the run ID if starting a new run
+    if run_id is None:
+        run_id = wandb.run.id
+        with open(run_id_file, 'w') as f:
+            f.write(run_id)
+        logger.info(f"Started new WandB run with id {run_id}")
+
+    return wandb


### PR DESCRIPTION
# **Changes**

### Refactored WandB Initialization into Shared Module

- **Abstracted WandB Initialization into `templar/wandb.py`:**
  - Created a new module `wandb.py` within the `templar` package to centralize WandB initialization.
  - Implemented the `initialize_wandb` function to handle run ID management and WandB configuration.
  - This abstraction eliminates code duplication between `miner.py` and `validator.py`.

- **Removed Code Duplication in `miner.py` and `validator.py`:**
  - Updated both `miner.py` and `validator.py` to use the shared `initialize_wandb` function.
  - Simplifies maintenance by having a single point of modification for WandB settings.

- **Grouped Runs by Version Number:**
   - Modified the project naming convention in WandB initialization to include the version number.
   - Runs are now grouped by version number, aiding in tracking experiments across different versions.
