### PR TITLE
Slice Submission Penalty

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -195,7 +195,6 @@ PM2 automatically manages your miner processes and restarts them if they crash:
     --netuid <netuid> \
     --subtensor.network <network> \
     --process_name miner \  # Must match PM2's --name
-    --remote \
     --sync_state
 
 
@@ -210,7 +209,6 @@ pm2 list
 
 ### Important Flags
 - **`--process_name`**: (Required) Must match the PM2 process name when using PM2
-- **`--remote`**: Enables downloading updates from other miners' buckets
 - **`--sync_state`**: Synchronizes model state with network history
 - **`--actual_batch_size`**: Set based on GPU memory:
   - 80GB+ VRAM: batch size 6
@@ -218,7 +216,7 @@ pm2 list
   - 24GB VRAM: batch size 1
 - **`--netuid`**: Network subnet ID (e.g., 223 for testnet)
 - **`--subtensor.network`**: Network name (finney/test/local)
-- **`--autoupdate`**: Enable automatic code updates
+- **`--no_autoupdate`**: Disable automatic code updates
 
 ## Configuration
 

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -193,8 +193,6 @@ pm2 start neurons/validator.py --interpreter python3 --name validator -- \
   --netuid <netuid> \
   --subtensor.network <network> \
   --process_name validator \  # Must match PM2's --name
-  --autoupdate \
-  --remote  \
   --sync_state
 
 > **Important**: When using PM2, the `--process_name` argument must match the PM2 process name specified by `--name`. In this example, PM2 process is named `validator`, so we use `--process_name validator`.
@@ -216,7 +214,7 @@ pm2 list
   - 24GB VRAM: batch size 1
 - **`--netuid`**: Network subnet ID (e.g., 223 for testnet)
 - **`--subtensor.network`**: Network name (finney/test/local)
-- **`--autoupdate`**: Enable automatic code updates
+- **`--no_autoupdate`**: Disable automatic code updates
 
 ## Configuration
 

--- a/hparams.json
+++ b/hparams.json
@@ -30,5 +30,6 @@
     "validator_norm_regularization": 0.01,
     "validator_weights_temperature": 10,
     "validator_window_eval_size": 3,
-    "valdiator_sample_rate": 0.01
+    "valdiator_sample_rate": 0.01,
+    "validator_non_submission_decay": 0.9
 }

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -213,7 +213,7 @@ class Miner:
         next_buckets = []
         for uid in self.metagraph.uids:
             try:
-                bucket = self.config.bucket if not self.config.remote else self.subtensor.get_commitment(self.config.netuid, uid)
+                bucket = self.subtensor.get_commitment(self.config.netuid, uid)
                 if tplr.is_valid_bucket(bucket):
                     tplr.logger.debug(f"UID {uid}: Valid bucket found: {bucket}")
                     next_buckets.append(bucket)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -59,7 +59,7 @@ class Miner:
         parser.add_argument('--baseline', action='store_true', help='Dont perform syncing with other peers, just train.')
         parser.add_argument('--test', action='store_true', help='Run on test network')
         parser.add_argument('--local', action='store_true', help='Run on local network')
-        parser.add_argument('--autoupdate', action='store_true', help='Enable automatic updates')
+        parser.add_argument('--no_autoupdate', action='store_true', help='Disable automatic updates')
         parser.add_argument("--process_name", type=str, help="The name of the PM2 process")
         parser.add_argument('--checkpoint_path', type=str, default=None, help='Path to save/load the checkpoint. If None, the path is set to checkpoint-M<UID>.pth.')
         bt.wallet.add_args(parser)
@@ -74,7 +74,7 @@ class Miner:
         if config.debug: tplr.debug()
         if config.trace: tplr.trace()
         tplr.validate_bucket_or_exit(config.bucket)
-        if config.autoupdate:
+        if not config.no_autoupdate:
             autoupdater = tplr.AutoUpdate(process_name=config.process_name, bucket_name=config.bucket)
             autoupdater.start()
         return config
@@ -175,9 +175,14 @@ class Miner:
         # Init buckets.
         self.buckets = []
         for uid in self.metagraph.uids:
-            # Use --remote to connect to other miners, other wise, only see's config.bucket.
-            try: self.buckets.append(self.config.bucket if not self.config.remote else self.subtensor.get_commitment( self.config.netuid, uid ) )
-            except: self.buckets.append(None)
+            try:
+                bucket =  self.subtensor.get_commitment(self.config.netuid, uid)
+                tplr.logger.debug(f"Retrieved bucket for UID {uid}: {bucket}")
+                self.buckets.append(bucket)
+            except Exception as e:
+                tplr.logger.debug(f"Failed to retrieve bucket for UID {uid}: {e}")
+                self.buckets.append(None)
+
 
         # Init run state.
         self.sample_rate = 1.0

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -187,7 +187,8 @@ class Miner:
         self.new_block_event = asyncio.Event()
         self.new_window_event = asyncio.Event()
         self.stop_event = asyncio.Event()    
-        self.last_full_steps = self.hparams.desired_batch_size // self.config.actual_batch_size    
+        self.last_full_steps = self.hparams.desired_batch_size // self.config.actual_batch_size
+        bt.logging.off    
         print ( self.hparams )
         
     async def update(self):
@@ -196,7 +197,7 @@ class Miner:
             st = tplr.T()
             await asyncio.to_thread(self.perform_update)
             tplr.logger.info(f"{tplr.P(self.current_window, tplr.T() - st)} Updated global state.")
-            await asyncio.sleep(600)
+            await asyncio.sleep(3600)
 
     def perform_update(self):
         """Updates subtensor connection, metagraph, hyperparameters and buckets."""

--- a/src/templar/__init__.py
+++ b/src/templar/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 # Import package.
 from .autoupdate import *


### PR DESCRIPTION
# **Changes**

### Adjusted Score Decay for Inactive Miners

- **Implemented Selective Score Decay in `validator.py`:**
  - Added logic to reduce the scores of miners who do not submit slices in the current window.
  - Introduced a new hyperparameter `validator_non_submission_decay` to control the decay factor.
  - Ensures that miners who stop producing slices see their scores drop to zero over time.

### Remote / Autoupdate on by default

-  In order to opt of of autoupdate , users need to pass the `--no_autoupdate` flag


### Benefits of Changes

- **Fair Score Adjustment**: Miners who stop submitting slices have their scores decrease, ensuring fairness in the validation process.
- **Reduce User Errors**: Not syncing peers is detrimental to the performance of both miners and the training run. This helps reduce the impact of that. 
