### PR TITLE
fix: Weight Setting Refactor

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -563,16 +563,17 @@ class Validator:
                     
                     wandb.log({f"validator/{metric_name}": line_plot}, step=self.global_step)
                 # Set temperatured weights on the chain.
-                if self.current_block % 100 == 0:
+                if self.global_step % 100 == 0:
                     tplr.logger.info(f"Setting weights on chain: {self.weights[ self.metagraph.uids ]}")
                     try:
-                        result = self.subtensor.set_weights(
-                            wallet = self.wallet,
-                            netuid = self.config.netuid,
-                            uids = self.metagraph.uids,
-                            weights = self.weights[ self.metagraph.uids ],
-                            wait_for_inclusion = True,
-                            wait_for_finalization = False,
+                        result = await asyncio.to_thread(
+                            self.subtensor.set_weights,
+                            wallet=self.wallet,
+                            netuid=self.config.netuid,
+                            uids=self.metagraph.uids,
+                            weights=self.weights[self.metagraph.uids],
+                            wait_for_inclusion=True,
+                            wait_for_finalization=False,
                         )
                         tplr.logger.info(f"Successfully set weights on chain: {result}")
                     except Exception as e:
@@ -583,7 +584,7 @@ class Validator:
                 tplr.logger.info("Training interrupted by user. Stopping the run.")
                 self.stop_event.setplr.T()
                 await self.update_task
-                sys.exitplr.T(0)
+                sys.exit(0)
             
             # Catch unknown.
             except Exception as e:


### PR DESCRIPTION
# **Changes**

### Moved Weight Setting Logic to Separate Thread

- **Modified `validator.py`:**
  - Refactored the weight-setting logic to run in a separate thread.
  - Prevents the event loop and block listener from being blocked during weight updates.
  - Addresses the issue where the validator could hang while setting weights.

### Adjusted Weight Update Frequency

- **Changed Weight Update Trigger:**
  - Updated the weight-setting process to occur every 100 global steps instead of every 100 blocks.
  - Ensures that weight updates are aligned with the training progression rather than block intervals.

### Benefits of Changes

- **Improved Validator Responsiveness**: Moving weight updates to a separate thread keeps the validator responsive and prevents it from hanging during intensive operations.
- **Aligned with Training Steps**: Adjusting the update frequency to global steps provides more consistent and timely weight adjustments in sync with the training process.
- **Enhanced Performance**: Reduces potential bottlenecks in the event loop, improving overall system efficiency.